### PR TITLE
Boot MU plugin conditionally

### DIFF
--- a/iconic-tpd.php
+++ b/iconic-tpd.php
@@ -17,9 +17,8 @@ function iconic_tpd_boot() {
 		include ABSPATH . 'wp-includes/pluggable.php';
 	}
 
-	$current_screen = get_current_screen();
-	// Boot only for administrators on the front-end.
-	if ( ! current_user_can( 'administrator' ) || 'plugins' === $current_screen->id ) {
+	// Boot only for administrators.
+	if ( ! current_user_can( 'administrator' ) || did_action( 'load-plugins.php' ) {
 		return;
 	}
 

--- a/iconic-tpd.php
+++ b/iconic-tpd.php
@@ -17,8 +17,8 @@ function iconic_tpd_boot() {
 		include ABSPATH . 'wp-includes/pluggable.php';
 	}
 
+	// Boot only for administrators on the front-end.
 	if ( ! current_user_can( 'administrator' ) || is_admin() ) {
-		// TODO Display admin notice.
 		return;
 	}
 


### PR DESCRIPTION
- [will not work as a normal plugin](https://developer.wordpress.org/reference/hooks/muplugins_loaded/)
- spares all those `is_enabled` checks
- ~~early admin page detection~~ 👈 _I think this will not work_

What do you think?
